### PR TITLE
Versions updated.

### DIFF
--- a/build-push-native-image/action.yml
+++ b/build-push-native-image/action.yml
@@ -47,7 +47,7 @@ runs:
           -Pnative \
           -Dmaven.test.skip=true \
           -Dquarkus.native.container-build=true \
-          -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image@sha256:ce70e1a8016471ff0fc9c8f048cd9e37afddacd3de37ed0bca74201d102e45f5 \
+          -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21@sha256:832c01753ebb631890a9302f989a66ae54424d41e1f09ba9a207d7d734a5acb5
           -s ${{ runner.temp }}/settings.xml \
           --no-transfer-progress
 

--- a/pr-validation/action.yml
+++ b/pr-validation/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: PR title validation
-      uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # 5.5.3
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
       env:
         GITHUB_TOKEN: ${{ inputs.gh_token }}
       with:
@@ -34,7 +34,7 @@ runs:
         wip: false
 
     - name: Setup Java Build Environment
-      uses: pagopa/mil-actions/setup-java-build-env@2950717fce7be3292c224475f72c36fb56a3539c # 1.2.0
+      uses: pagopa/mil-actions/setup-java-build-env@372a6b1b566cf0973539b95bcc38a389aa35d5b6 # 1.3.0
       with:
         gh_user: ${{ inputs.gh_user }}
         gh_token: ${{ inputs.gh_token }}


### PR DESCRIPTION
- amannn/action-semantic-pull-request: 5.5.3 -> 6.1.1
- pagopa/mil-actions/setup-java-build-env: 1.2.0 -> 1.3.0
- quarkus.native.builder-image:
    quay.io/quarkus/ubi-quarkus-mandrel-builder-image ->
    quay.io/quarkus/ubi9-quarkus-mandrel-builder-image