### PR TITLE
feat: Update builder image and Java/Maven versions

### DIFF
--- a/build-push-native-image/action.yml
+++ b/build-push-native-image/action.yml
@@ -47,7 +47,7 @@ runs:
           -Pnative \
           -Dmaven.test.skip=true \
           -Dquarkus.native.container-build=true \
-          -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21@sha256:832c01753ebb631890a9302f989a66ae54424d41e1f09ba9a207d7d734a5acb5 \
+          -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25.0.3@sha256:bf13d8b47e1022b17d3662c1a4914c099766830f6e7e5293b1611cdf60e22b1b \
           -s ${{ runner.temp }}/settings.xml \
           --no-transfer-progress
 

--- a/setup-java-build-env/action.yml
+++ b/setup-java-build-env/action.yml
@@ -14,10 +14,10 @@ runs:
     # Cache JDK.
     #
     - name: Cache JDK
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # 4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.3
       id: cache-jdk
       with:
-        key: OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz
+        key: OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz
         path: |
           ${{ runner.temp }}/jdk_setup.tar.gz
           ${{ runner.temp }}/jdk_setup.sha256
@@ -29,29 +29,29 @@ runs:
       if: steps.cache-jdk.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo "f2dc5418092c43003db8f9005c4a286e1c0104fea96ccdd49e8ebd037cac9219  ${{ runner.temp }}/jdk_setup.tar.gz" >> ${{ runner.temp }}/jdk_setup.sha256
-        curl -L "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz" -o "${{ runner.temp }}/jdk_setup.tar.gz"
+        echo "69264a7a211bf5029830d07bc3370f879769d62ebc5b5488e90c9343a2da0e1f  ${{ runner.temp }}/jdk_setup.tar.gz" >> ${{ runner.temp }}/jdk_setup.sha256
+        curl -L "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz" -o "${{ runner.temp }}/jdk_setup.tar.gz"
         sha256sum --check --status "${{ runner.temp }}/jdk_setup.sha256"
 
     #
     # Setup JDK.
     #
     - name: Setup JDK
-      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # 5.0.0
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
       with:
         distribution: "jdkfile"
         jdkFile: "${{ runner.temp }}/jdk_setup.tar.gz"
-        java-version: "21"
+        java-version: "25"
         cache: maven
 
     #
     # Cache Maven.
     #
     - name: Cache Maven
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # 4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.3
       id: cache-maven
       with:
-        key: apache-maven-3.9.11-bin.tar.gz
+        key: apache-maven-3.9.15-bin.tar.gz
         path: |
           ${{ runner.temp }}/maven_setup.tar.gz
           ${{ runner.temp }}/maven_setup.sha512
@@ -63,8 +63,8 @@ runs:
       if: steps.cache-maven.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo "bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978  ${{ runner.temp }}/maven_setup.tar.gz" >> ${{ runner.temp }}/maven_setup.sha512
-        curl -L "https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz" -o "${{ runner.temp }}/maven_setup.tar.gz"
+        echo "33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3  ${{ runner.temp }}/maven_setup.tar.gz" >> ${{ runner.temp }}/maven_setup.sha512
+        curl -L "https://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz" -o "${{ runner.temp }}/maven_setup.tar.gz"
         sha512sum --check --status "${{ runner.temp }}/maven_setup.sha512"
 
     #


### PR DESCRIPTION
This pull request updates the Java build environment to use newer versions of the JDK and Maven, and also refreshes related GitHub Actions dependencies. The primary goal is to upgrade from JDK 21 to JDK 25 and Maven 3.9.11 to Maven 3.9.15, ensuring the build process uses the latest stable tools and images.

**Build environment upgrades:**

* Updated JDK version from 21 to 25 throughout the `setup-java-build-env/action.yml` workflow, including cache keys, download URLs, and the `setup-java` action configuration. [[1]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L17-R20) [[2]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L32-R54)
* Updated Maven version from 3.9.11 to 3.9.15 in cache keys, download URLs, and hash verification within `setup-java-build-env/action.yml`. [[1]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L32-R54) [[2]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L66-R67)

**Dependency and builder image updates:**

* Upgraded the builder image in `build-push-native-image/action.yml` to use JDK 25 (`quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25.0.3`) instead of JDK 21.
* Updated GitHub Actions versions for `actions/cache` and `actions/setup-java` to their latest releases in `setup-java-build-env/action.yml`. [[1]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L17-R20) [[2]](diffhunk://#diff-a926ce63794d3c6556c35b147709c3f31c3365fe4a8da18b7cae82213a3ec726L32-R54)