### PR TITLE
fix: Update setup-java-build-env action to version 1.5.0

### DIFF
--- a/pr-validation/action.yml
+++ b/pr-validation/action.yml
@@ -34,7 +34,7 @@ runs:
         wip: false
 
     - name: Setup Java Build Environment
-      uses: pagopa/mil-actions/setup-java-build-env@372a6b1b566cf0973539b95bcc38a389aa35d5b6 # 1.3.0
+      uses: pagopa/mil-actions/setup-java-build-env@a4f8193573636c9650b1285d297ab20c35c5ceea # 1.5.0
       with:
         gh_user: ${{ inputs.gh_user }}
         gh_token: ${{ inputs.gh_token }}


### PR DESCRIPTION
This pull request updates the Java build environment setup action to use a newer version. This ensures the workflow benefits from the latest features, improvements, and potential bug fixes.

Dependency update:

* Updated the `pagopa/mil-actions/setup-java-build-env` action in `action.yml` from version `1.3.0` to `1.5.0` to leverage improvements and fixes in the newer release.