### PR TITLE
feat: Add 'latest' tag option for container image in build-push-native-image action

### DIFF
--- a/build-push-native-image/action.yml
+++ b/build-push-native-image/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: True to skip Maven's test execution
     required: false
     default: "false"
+  latest:
+    description: True to also tag the container image as latest
+    required: false
+    default: "false"
 outputs:
   image:
     description: "Built image"
@@ -58,10 +62,17 @@ runs:
       shell: bash
       env:
         RELEASE_VERSION: ${{ inputs.release_version }}
+        LATEST: ${{ inputs.latest }}
       run: |
+        TAGS="-t ghcr.io/${{ github.repository }}:$RELEASE_VERSION"
+
+        if [ "$LATEST" = "true" ]; then
+          TAGS="$TAGS -t ghcr.io/${{ github.repository }}:latest"
+        fi
+
         docker build \
           -f src/main/docker/Dockerfile.native-micro \
-          -t ghcr.io/${{ github.repository }}:$RELEASE_VERSION \
+          $TAGS \
           .
 
     #


### PR DESCRIPTION
This pull request updates the `build-push-native-image` GitHub Action to add support for optionally tagging the built container image as `latest`. This gives users more flexibility in how images are tagged during the build process.

**New feature: Optional `latest` tag for container images**
- Added a new input parameter `latest` to `action.yml` that allows users to specify whether the built image should also be tagged as `latest`.
- Updated the build script to conditionally add the `latest` tag to the Docker build command if the `latest` input is set to `true`.