### PR TITLE
fix: Simplify installation steps for Argo CD in action.yml

### DIFF
--- a/update-deploy-aks/action.yml
+++ b/update-deploy-aks/action.yml
@@ -236,12 +236,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        echo "fb230f97ba87b393746accf167067e0b75d20d2de5ee7cf847d50d4361f92e5f  ${{ runner.temp }}/argocd-linux-amd64" >> ${{ runner.temp }}/argocd-linux-amd64.sha256
-        curl -L "https://github.com/argoproj/argo-cd/releases/download/v3.4.3/argocd-linux-amd64" -o "${{ runner.temp }}/argocd-linux-amd64"
-        sha256sum --check --status "${{ runner.temp }}/argocd-linux-amd64.sha256"
-        mkdir -p "${{ runner.temp }}/argocd"
-        install -m 555 argocd-linux-amd64 "${{ runner.temp }}/argocd/argocd"
-        rm argocd-linux-amd64
+        cd "${{ runner.temp }}"
+        echo "fb230f97ba87b393746accf167067e0b75d20d2de5ee7cf847d50d4361f92e5f  argocd-linux-amd64" >> argocd-linux-amd64.sha256
+        curl -L "https://github.com/argoproj/argo-cd/releases/download/v3.4.3/argocd-linux-amd64" -o argocd-linux-amd64
+        sha256sum --check --status argocd-linux-amd64.sha256
+        mkdir -p argocd
+        install -m 555 argocd-linux-amd64 argocd/argocd
+        rm argocd-linux-amd64 argocd-linux-amd64.sha256
         echo "${{ runner.temp }}/argocd" >> "$GITHUB_PATH"
 
     #


### PR DESCRIPTION
This pull request refactors the installation steps for the ArgoCD CLI in the `update-deploy-aks/action.yml` workflow. The main improvement is simplifying file handling by performing all operations within the `${{ runner.temp }}` directory, which makes the script more robust and easier to maintain.

**Improvements to installation process:**

* All operations (`curl`, checksum verification, extraction, and cleanup) are now performed after changing into the `${{ runner.temp }}` directory, reducing path complexity and potential errors.
* The script now removes both the downloaded binary and its checksum file after installation, ensuring a cleaner runner environment.